### PR TITLE
Set exact screen size for Karma Testing

### DIFF
--- a/karma-ci.conf.js
+++ b/karma-ci.conf.js
@@ -34,7 +34,7 @@ module.exports = function(config) {
 
 		reporters: ['progress', 'coverage'],
 
-		browsers: ['ChromeHeadless'],
+		browsers: ['CustomChromeHeadless'],
 
 		singleRun: true
 	});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,10 @@
 module.exports = function(config) {
 	"use strict";
 
+	var chromeFlags = [
+		"--window-size=1280,1024"
+	];
+
 	config.set({
 
 		frameworks: ['ui5'],
@@ -17,7 +21,18 @@ module.exports = function(config) {
 
 		autoWatch: true,
 
-		browsers: ['Chrome'],
+		customLaunchers: {
+			CustomChrome: {
+				base: "Chrome",
+				flags: chromeFlags
+			},
+			CustomChromeHeadless: {
+				base: "ChromeHeadless",
+				flags: chromeFlags
+			}
+		},
+
+		browsers: ['CustomChrome'],
 
 		singleRun: false
 	});


### PR DESCRIPTION
Chrome and Chrome Headless use a different default screen size.
This caused the tests to fail in Headless, as the screen was only
800px wide.
To use the same size in both variants is it passed as CLI argument.

Follow-up of #19 