### PR TITLE
chore: upgrade to UI5 version 1.79.0 and theme fiori 3

### DIFF
--- a/ui5.yaml
+++ b/ui5.yaml
@@ -4,10 +4,10 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.78.1"
+  version: "1.79.0"
   libraries:
     - name: sap.f
     - name: sap.m
     - name: sap.ui.core
     - name: sap.ui.layout
-    - name: themelib_sap_belize
+    - name: themelib_sap_fiori_3

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -7,7 +7,7 @@
 
 	<script id="sap-ui-bootstrap"
 			src="resources/sap-ui-core.js"
-			data-sap-ui-theme="sap_belize"
+			data-sap-ui-theme="sap_fiori_3"
 			data-sap-ui-resourceroots='{
 				"sap.ui.demo.masterdetail": "./"
 			}'

--- a/webapp/test.html
+++ b/webapp/test.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Testing Overview</title>
 	<!-- try to load the basic UI5 styles -->
-	<link rel="stylesheet" type="text/css" href="resources/sap/ui/core/themes/sap_belize/library.css">
+	<link rel="stylesheet" type="text/css" href="resources/sap/ui/core/themes/sap_fiori_3/library.css">
 </head>
 <body class="sapUiBody sapUiMediumMargin sapUiForceWidthAuto">
 	<h1>Testing Overview</h1>

--- a/webapp/test/integration/opaTests.qunit.html
+++ b/webapp/test/integration/opaTests.qunit.html
@@ -6,7 +6,7 @@
 
 	<script id="sap-ui-bootstrap"
 			src="../../resources/sap-ui-core.js"
-			data-sap-ui-theme='sap_belize'
+			data-sap-ui-theme='sap_fiori_3'
 			data-sap-ui-resourceroots='{
 				"sap.ui.demo.masterdetail": "../../"
 			}'

--- a/webapp/test/integration/opaTestsPhone.qunit.html
+++ b/webapp/test/integration/opaTestsPhone.qunit.html
@@ -6,7 +6,7 @@
 
 	<script id="sap-ui-bootstrap"
 			src="../../resources/sap-ui-core.js"
-			data-sap-ui-theme='sap_belize'
+			data-sap-ui-theme='sap_fiori_3'
 			data-sap-ui-resourceroots='{
 				"sap.ui.demo.masterdetail": "../../"
 			}'

--- a/webapp/test/mockServer.html
+++ b/webapp/test/mockServer.html
@@ -7,7 +7,7 @@
 
 	<script id="sap-ui-bootstrap"
 			src="../resources/sap-ui-core.js"
-			data-sap-ui-theme="sap_belize"
+			data-sap-ui-theme="sap_fiori_3"
 			data-sap-ui-resourceroots='{
 				"sap.ui.demo.masterdetail": "../"
 			}'


### PR DESCRIPTION
This PR upgrades the app to UI5 version 1.79.0 and uses the sap fiori 3 theme.